### PR TITLE
Descriptive error when transit uncompiled, better PEP 8 compliance

### DIFF
--- a/pysyzygy/main.py
+++ b/pysyzygy/main.py
@@ -12,12 +12,18 @@ Copyright Rodrigo Luger, May 2015.
 """
 
 import matplotlib.pyplot as pl
-import transit
 import numpy as np
 from scipy.optimize import newton
 import os, sys, subprocess
 G = 6.672e-8
 DAYSEC = 86400
+
+try:
+  import transit
+except ImportError:
+  raise ImportError('Failed to import the transit module. Did you compile the '
+                    'transit.f file? To do so, cd to pysyzygy/pysyzygy and '
+                    'run:\n\n    >>> f2py -c transit.f -m transit\n\n')
 
 __all__ = ['lightcurve', 'xy', 'plot', 'I', 'animate']
 


### PR DESCRIPTION
The [first update](https://github.com/rodluger/pysyzygy/commit/4f4596e5d8a1cc1c7d0f6853c3aea1ec152e7891) simply gives users a better error message if they run pysyzygy before transit.f is compiled, like this: 

```
% python -c 'import pysyzygy'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "pysyzygy/__init__.py", line 5, in <module>
    from .main import *
  File "pysyzygy/main.py", line 24, in <module>
    raise ImportError('Failed to import the transit module. Did you compile the '
ImportError: Failed to import the transit module. Did you compile the transit.f file? 
To do so, cd to pysyzygy/pysyzygy and run:

    >>> f2py -c transit.f -m transit

```

The [second update](https://github.com/rodluger/pysyzygy/commit/8af81c9e7a059315d50c61a29700fa9c58196b6e) is bigger and scarier and reformats all of the code in `main.py` to look like the Python gods demand it should. This feat of piety was accomplished with [PyCharm's Reformatting Source Code](https://www.jetbrains.com/pycharm/help/reformatting-source-code.html) command, and I'm trusting that it did a good job (of course, I've tested that the code still runs).
